### PR TITLE
Fixing IPN hash (part 2)

### DIFF
--- a/src/Tuxxx128/G2aPay/G2aPayApi.php
+++ b/src/Tuxxx128/G2aPay/G2aPayApi.php
@@ -106,7 +106,7 @@ class G2aPayApi implements IG2aPay
     public function calculateIpnHash($transactionId, $orderId, $amount)
     {
         return hash('sha256',
-            $transactionId.$orderId.(number_format($amount, 2) + 0).$this->secretKey);
+            $transactionId.$orderId.(number_format($amount, 2, '.', '') + 0).$this->secretKey);
     }
 
     /**


### PR DESCRIPTION
Hey, you may remember a while back I opened an issue for this and you have implemented it (thanks!). Well recently the sites which I use g2a on have had a lot of orders over 1000 and the IPNs have been failing. After debugging I found the cause of the issue was the hash - as number_format(int, 2) when over 1000 will include a comma and ends up breaking it. 

tl;dr - removes the thousands separator so it will no longer break for orders over 1000